### PR TITLE
Upgrade pgxn_meta and add download validation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
-/Cargo.lock -diff
+# Disable line-ending conversion of JSON files, so that the hash digest
+# validation tests pass on Windows.
+*.json         -text

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,7 +1284,7 @@ dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -1566,7 +1566,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.3",
  "ureq",
  "url",
  "zip",
@@ -1574,14 +1574,17 @@ dependencies = [
 
 [[package]]
 name = "pgxn_meta"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff48b8bcb2e7677cea3fc0ffc88a6ff830a95a88e0f78ebb2778ee29f095442"
+checksum = "8e9868dbed1723491858593133d5763ff773cce4dc6042826a6743c28a1f4e5e"
 dependencies = [
  "base64 0.22.1",
  "boon",
  "chrono",
+ "constant_time_eq",
+ "digest",
  "email_address",
+ "hex",
  "json-patch",
  "lexopt",
  "rand",
@@ -1590,7 +1593,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sha1",
+ "sha2",
  "spdx",
+ "thiserror 2.0.3",
  "wax",
 ]
 
@@ -1748,7 +1754,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -2045,9 +2051,9 @@ dependencies = [
 
 [[package]]
 name = "spdx"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc"
+checksum = "bae30cc7bfe3656d60ee99bf6836f472b0c53dddcbf335e253329abb16e535a2"
 dependencies = [
  "smallvec",
 ]
@@ -2124,9 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2152,7 +2158,16 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.68",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -2160,6 +2175,17 @@ name = "thiserror-impl"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2484,7 +2510,7 @@ dependencies = [
  "nom",
  "pori",
  "regex",
- "thiserror",
+ "thiserror 1.0.68",
  "walkdir",
 ]
 
@@ -2771,7 +2797,7 @@ dependencies = [
  "pbkdf2",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
  "zeroize",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,27 @@
 [package]
 name = "pgxn_build"
 version = "0.1.0"
+description = "Build PGXN distributions"
+repository = "https://github.com/pgxn/build"
+documentation = "https://docs.rs/pgxn_build/"
+authors = ["David E. Wheeler <david@justatheory.com>"]
+readme = "README.md"
+keywords = ["pgxn", "postgres", "postgresql", "extension", "validation"]
+license = "PostgreSQL"
+categories = ["web-programming", "database"]
 edition = "2021"
+exclude = [ ".github", ".vscode", ".gitignore", ".ci", ".pre-*.yaml"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 chrono = "0.4"
 iri-string = "0.7"
-pgxn_meta = "0.4"
+pgxn_meta = "0.5.1"
 semver = "1.0"
 serde = "1.0"
 serde_json = "1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 ureq = { version = "*", features = ["json"] }
 url = "2.5"
 zip = "2.2"
@@ -18,5 +29,5 @@ zip = "2.2"
 [dev-dependencies]
 httpmock = "0.7"
 sha2 = "0.10"
-tempfile = "3.12"
+tempfile = "3.14"
 hex = "0.4"

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -58,8 +58,8 @@ pub enum BuildError {
     Invalid(&'static str),
 
     /// Unexpected pgxn_meta error.
-    #[error("{0}")]
-    InvalidMeta(String),
+    #[error(transparent)]
+    InvalidMeta(#[from] pgxn_meta::error::Error),
 
     /// Zip archive error.
     #[error("{0}")]


### PR DESCRIPTION
Take advantage of the errors defined in pgxn_meta v0.5.0 rather than stringifying them. Add tests for errors returned by the `meta` and `download` APIs.

Change the signature for `download_to` to take a pgxn_meta Release struct instead of a distribution name and version. Then use the Release both to determine the name and version to download, and then to validate the download against the digests in the Release. Update the tests for the new signature, and to ensure digest validation.