### PR TITLE
Cover overlooked branches

### DIFF
--- a/.ci/test-cover
+++ b/.ci/test-cover
@@ -17,6 +17,7 @@ grcov "${DESTDIR}" \
     --ignore-not-existing \
     --ignore '**/tests/**' \
     --ignore 'build.rs' \
+    --ignore 'target/**' \
     --excl-start '#(\[cfg\(test\)\]|\[test\])' \
     --excl-line 'unreachable\!\(\)' \
     --llvm \

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,7 @@ VERSION = $(shell perl -nE '/^version\s*=\s*"([^"]+)/ && do { say $$1; exit }' C
 .PHONY: release-notes # Show release notes for current version (must have `mknotes` in PATH).
 release-notes: CHANGELOG.md
 	mknotes -v v$(VERSION) -f $< -r https://github.com/$(or $(GITHUB_REPOSITORY),pgxn/meta)
+
+.PHONY: clean # Remove generated files
+clean:
+	@rm -rf target


### PR DESCRIPTION
I got test coverage fixed in my Mac, so could see what I've missed in the last several commits. Fill those gaps as best as possible. There is only one branch I can't figure out how to trigger: copying from an http request to a file. Perhaps in the future we'll update the Api struct to support dependency injection, or switch to some more mockable request agent. But in the meantime, use a macro to reduce that branch to a single line.

Other changes: Eliminate an error check where the url docs say there will never be an error, add a `clean` target to the `Makefile`, and convert `type_of` to a macro.