### PR TITLE
Pass build directory to pipelines

### DIFF
--- a/src/pgrx/mod.rs
+++ b/src/pgrx/mod.rs
@@ -4,20 +4,22 @@
 
 use crate::error::BuildError;
 use crate::pipeline::Pipeline;
-use pgxn_meta::release::Release;
+use std::path::PathBuf;
 
 /// Builder implementation for [pgrx] Pipelines.
 ///
 /// [pgrx]: https://github.com/pgcentralfoundation/pgrx
 #[derive(Debug, PartialEq)]
 pub(crate) struct Pgrx {
-    meta: Release,
+    dir: PathBuf,
+    sudo: bool,
 }
 
 impl Pipeline for Pgrx {
-    fn new(meta: Release) -> Self {
-        Pgrx { meta }
+    fn new(dir: PathBuf, sudo: bool) -> Self {
+        Pgrx { dir, sudo }
     }
+
     fn configure(&self) -> Result<(), BuildError> {
         Ok(())
     }

--- a/src/pgxs/mod.rs
+++ b/src/pgxs/mod.rs
@@ -4,19 +4,20 @@
 
 use crate::error::BuildError;
 use crate::pipeline::Pipeline;
-use pgxn_meta::release::Release;
+use std::path::PathBuf;
 
 /// Builder implementation for [PGXS] Pipelines.
 ///
 /// [PGXS]: https://www.postgresql.org/docs/current/extend-pgxs.html
 #[derive(Debug, PartialEq)]
 pub(crate) struct Pgxs {
-    meta: Release,
+    dir: PathBuf,
+    sudo: bool,
 }
 
 impl Pipeline for Pgxs {
-    fn new(meta: Release) -> Self {
-        Pgxs { meta }
+    fn new(dir: PathBuf, sudo: bool) -> Self {
+        Pgxs { dir, sudo }
     }
 
     fn configure(&self) -> Result<(), BuildError> {

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -1,13 +1,13 @@
 //! Build Pipeline interface definition.
 
 use crate::error::BuildError;
-use pgxn_meta::release::Release;
+use std::path::PathBuf;
 
 /// Defines the interface for build pipelines to configure, compile, and test
 /// PGXN distributions.
 pub(crate) trait Pipeline {
     /// Creates an instance of a Builder.
-    fn new(meta: Release) -> Self;
+    fn new(dir: PathBuf, sudo: bool) -> Self;
 
     /// Configures a distribution to build on a particular platform and
     /// Postgres version.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -33,13 +33,15 @@ fn release_meta(pipeline: &str) -> Value {
 fn pgxs() {
     // Test pgxs pipeline.
     let meta = release_meta("pgxs");
+    let dir = Path::new("dir");
     let rel = Release::try_from(meta.clone()).unwrap();
-    let builder = Builder::new(rel).unwrap();
+    let builder = Builder::new(dir, rel).unwrap();
     let rel = Release::try_from(meta).unwrap();
-    let exp = Builder(Build::Pgxs(Pgxs::new(rel)));
+    let exp = Builder {
+        pipeline: Build::Pgxs(Pgxs::new(dir.to_path_buf(), true)),
+        meta: rel,
+    };
     assert_eq!(exp, builder, "pgxs");
-    assert!(builder.download().is_ok());
-    assert!(builder.unpack().is_ok());
     assert!(builder.configure().is_ok());
     assert!(builder.compile().is_ok());
     assert!(builder.test().is_ok());
@@ -49,13 +51,15 @@ fn pgxs() {
 fn pgrx() {
     // Test pgrx pipeline.
     let meta = release_meta("pgrx");
+    let dir = Path::new("dir");
     let rel = Release::try_from(meta.clone()).unwrap();
-    let builder = Builder::new(rel).unwrap();
+    let builder = Builder::new(dir, rel).unwrap();
     let rel = Release::try_from(meta).unwrap();
-    let exp = Builder(Build::Pgrx(Pgrx::new(rel)));
+    let exp = Builder {
+        pipeline: Build::Pgrx(Pgrx::new(dir.to_path_buf(), true)),
+        meta: rel,
+    };
     assert_eq!(exp, builder, "pgrx");
-    assert!(builder.download().is_ok());
-    assert!(builder.unpack().is_ok());
     assert!(builder.configure().is_ok());
     assert!(builder.compile().is_ok());
     assert!(builder.test().is_ok());
@@ -68,7 +72,7 @@ fn unsupported_pipeline() {
     let rel = Release::try_from(meta).unwrap();
     assert_eq!(
         BuildError::UnknownPipeline("meson".to_string()).to_string(),
-        Builder::new(rel).unwrap_err().to_string(),
+        Builder::new("dir", rel).unwrap_err().to_string(),
     );
 }
 
@@ -79,7 +83,7 @@ fn detect_pipeline() {
     let mut meta = release_meta("");
     meta.as_object_mut().unwrap().remove("dependencies");
     let rel = Release::try_from(meta).unwrap();
-    _ = Builder::new(rel);
+    _ = Builder::new("dir", rel);
 }
 
 #[test]
@@ -98,5 +102,5 @@ fn no_pipeline() {
     deps.remove("pipeline");
     deps.insert("postgres".to_string(), json!({"version": "14"}));
     let rel = Release::try_from(meta).unwrap();
-    _ = Builder::new(rel);
+    _ = Builder::new("dir", rel);
 }


### PR DESCRIPTION
Instead of the release metadata. The build pipelines don't care about the metadata, but need to know the directory in which to execute. Also add a placeholder for using `sudo`.

Use a `PathBuf` in the pipeline implementations, rather than `AsRef<Path>`, mostly because I couldn't figure out the proper incantation to hold onto an `AsRef` through a trait definition. Not worth the time, so just convert to a `PathBuf` and worry about it later (if ever).

Hold onto the metadata in the parent method, however, as it may well need to use it at some point. This requires a bit of futzing while looking for the pipeline type in the metadata. Will implement the pipeline-detection `todo!()`s next to address it.

While at it, remove the `download` and `unpack` methods from `Builder`, as they're implemented by `api::Api`.