### PR TITLE
Implemented pipeline detection for PGXS and pgrx

### DIFF
--- a/.ci/test-cover
+++ b/.ci/test-cover
@@ -19,7 +19,7 @@ grcov "${DESTDIR}" \
     --ignore 'build.rs' \
     --ignore 'target/**' \
     --excl-start '#(\[cfg\(test\)\]|\[test\])' \
-    --excl-line 'unreachable\!\(\)' \
+    --excl-line 'unreachable\!\(' \
     --llvm \
     --binary-path "target/debug/" \
     -s . \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_toml"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88da5a13c620b4ca0078845707ea9c3faf11edbc3ffd8497d11d686211cd1ac0"
+dependencies = [
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,12 +1566,14 @@ dependencies = [
 name = "pgxn_build"
 version = "0.1.0"
 dependencies = [
+ "cargo_toml",
  "chrono",
  "hex",
  "httpmock",
  "iri-string",
  "log",
  "pgxn_meta",
+ "regex",
  "semver",
  "serde",
  "serde_json",
@@ -1941,6 +1953,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2283,6 +2304,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap 2.6.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2655,6 +2710,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ exclude = [ ".github", ".vscode", ".gitignore", ".ci", ".pre-*.yaml"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cargo_toml = "0.20.5"
 chrono = "0.4.38"
 hex = "0.4.3"
 iri-string = "0.7.7"
 log = { version = "0.4.22", features = ["kv"] }
 pgxn_meta = "0.5.1"
+regex = "1.11.1"
 semver = "1.0.23"
 serde = "1.0.215"
 serde_json = "1.0.133"

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -13,6 +13,10 @@ pub enum BuildError {
     #[error("unknown build pipeline `{0}`")]
     UnknownPipeline(String),
 
+    /// Unable to detect the pipeline.
+    #[error("cannot detect build pipeline and none specified")]
+    NoPipeline(),
+
     /// IO error.
     #[error(transparent)]
     Io(#[from] io::Error),

--- a/src/pgrx/mod.rs
+++ b/src/pgrx/mod.rs
@@ -4,7 +4,10 @@
 
 use crate::error::BuildError;
 use crate::pipeline::Pipeline;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+#[cfg(test)]
+mod tests;
 
 /// Builder implementation for [pgrx] Pipelines.
 ///
@@ -20,15 +23,45 @@ impl Pipeline for Pgrx {
         Pgrx { dir, sudo }
     }
 
+    /// Determines the confidence that the Pgrx pipeline can build the
+    /// contents of `dir`. Returns 255 if it contains a file named
+    /// `Cargo.toml` and lists pgrx as a dependency. Otherwise returns 1 if
+    /// `Cargo.toml` exists and 0 if it does not.
+    fn confidence(dir: &Path) -> u8 {
+        let file = dir.join("Cargo.toml");
+        if !file.exists() {
+            return 0;
+        }
+
+        // Does Cargo.toml mention pgrx?
+        if let Ok(cargo) = cargo_toml::Manifest::from_path(file) {
+            if cargo.dependencies.contains_key("pgrx") {
+                // Full confidence
+                return 255;
+            }
+        }
+
+        // Have Cargo.toml but no dependence on pgrx. Weak confidence.
+        1
+    }
+
+    /// Runs `cargo init`.
     fn configure(&self) -> Result<(), BuildError> {
         Ok(())
     }
 
+    /// Runs `cargo build`.
     fn compile(&self) -> Result<(), BuildError> {
         Ok(())
     }
 
+    /// Runs `cargo test`.
     fn test(&self) -> Result<(), BuildError> {
+        Ok(())
+    }
+
+    /// Runs `cargo install`.
+    fn install(&self) -> Result<(), BuildError> {
         Ok(())
     }
 }

--- a/src/pgrx/tests.rs
+++ b/src/pgrx/tests.rs
@@ -1,0 +1,48 @@
+use super::*;
+use std::{fs::File, io::Write};
+use tempfile::tempdir;
+
+#[test]
+fn confidence() -> Result<(), BuildError> {
+    let tmp = tempdir()?;
+    // No Cargo.toml.
+    assert_eq!(0, Pgrx::confidence(tmp.as_ref()));
+
+    // Create a Cargo.toml.
+    let mut file = File::create(tmp.as_ref().join("Cargo.toml"))?;
+    assert_eq!(1, Pgrx::confidence(tmp.as_ref()));
+
+    // Add a pgrx dependency.
+    writeln!(&file, "[dependencies]\npgrx = \"0.12.6\"")?;
+    file.flush().unwrap();
+    assert_eq!(255, Pgrx::confidence(tmp.as_ref()));
+
+    // Add another dependency (to be ignored).
+    writeln!(&file, "serde_json = \"1.0\"")?;
+    assert_eq!(255, Pgrx::confidence(tmp.as_ref()));
+
+    Ok(())
+}
+
+#[test]
+fn new() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let pipe = Pgrx::new(dir.to_path_buf(), false);
+    assert_eq!(dir, pipe.dir);
+    assert!(!pipe.sudo);
+
+    let dir2 = dir.join("corpus");
+    let pipe = Pgrx::new(dir2.to_path_buf(), true);
+    assert_eq!(dir2, pipe.dir);
+    assert!(pipe.sudo);
+}
+
+#[test]
+fn configure_et_al() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let pipe = Pgrx::new(dir.to_path_buf(), false);
+    assert!(pipe.configure().is_ok());
+    assert!(pipe.compile().is_ok());
+    assert!(pipe.test().is_ok());
+    assert!(pipe.install().is_ok());
+}

--- a/src/pgxs/mod.rs
+++ b/src/pgxs/mod.rs
@@ -4,7 +4,15 @@
 
 use crate::error::BuildError;
 use crate::pipeline::Pipeline;
-use std::path::PathBuf;
+use regex::Regex;
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+};
+
+#[cfg(test)]
+mod tests;
 
 /// Builder implementation for [PGXS] Pipelines.
 ///
@@ -20,6 +28,45 @@ impl Pipeline for Pgxs {
         Pgxs { dir, sudo }
     }
 
+    /// Determines the confidence that the Pgxs pipeline can build the
+    /// contents of `dir`. Returns 0 unless the directory contains a Makefile.
+    /// Otherwise it returns a score as follows;
+    ///
+    /// *   Returns 255 if it declares a variable named `PG_CONFIG`.
+    /// *   Returns 200 if it declares variables named `MODULES`,
+    ///     `MODULE_big`, `PROGRAM`, `EXTENSION`, `DATA`, or `DATA_built`
+    /// *   Otherwise returns 127
+    fn confidence(dir: &Path) -> u8 {
+        let file = match makefile(dir) {
+            Some(f) => f,
+            None => return 0,
+        };
+
+        // https://www.postgresql.org/docs/current/extend-pgxs.html
+        // https://github.com/postgres/postgres/blob/master/src/makefiles/pgxs.mk
+        let mut score: u8 = 127;
+        if let Ok(file) = File::open(file) {
+            let reader = BufReader::new(file);
+            let pgc_rx = Regex::new(r"^PG_CONFIG\s*[:?]?=\s*").unwrap();
+            let var_rx =
+                Regex::new(r"^(MODULE(?:S|_big)|PROGRAM|EXTENSION|DATA(?:_built)?)\s*[:?]?=")
+                    .unwrap();
+            for line in reader.lines().map_while(Result::ok) {
+                if pgc_rx.is_match(&line) {
+                    // Full confidence
+                    return 255;
+                }
+                if var_rx.is_match(&line) {
+                    // Probably
+                    score = 200;
+                }
+            }
+        }
+
+        // Probably can do `make all && make install`, probably not `installcheck`.
+        score
+    }
+
     fn configure(&self) -> Result<(), BuildError> {
         Ok(())
     }
@@ -31,4 +78,18 @@ impl Pipeline for Pgxs {
     fn test(&self) -> Result<(), BuildError> {
         Ok(())
     }
+
+    fn install(&self) -> Result<(), BuildError> {
+        Ok(())
+    }
+}
+
+fn makefile(dir: &Path) -> Option<PathBuf> {
+    for makefile in ["GNUmakefile", "makefile", "Makefile"] {
+        let file = dir.join(makefile);
+        if file.exists() {
+            return Some(file);
+        }
+    }
+    None
 }

--- a/src/pgxs/tests.rs
+++ b/src/pgxs/tests.rs
@@ -1,0 +1,73 @@
+use super::*;
+use std::{
+    fs::{self, File},
+    io::Write,
+};
+use tempfile::tempdir;
+
+#[test]
+fn confidence() -> Result<(), BuildError> {
+    let tmp = tempdir()?;
+    // No Makefile.
+    assert_eq!(0, Pgxs::confidence(tmp.as_ref()));
+
+    // Create each variant of a makefile.
+    for name in ["GNUmakefile", "makefile", "Makefile"] {
+        let makefile = tmp.as_ref().join(name);
+        let _file = File::create(&makefile)?;
+        assert_eq!(127, Pgxs::confidence(tmp.as_ref()), "{name} exists");
+
+        // With variables.
+        for var in [
+            "MODULES",
+            "MODULE_big",
+            "PROGRAM",
+            "EXTENSION",
+            "DATA",
+            "DATA_built",
+        ] {
+            for (i, op) in ["=", "=", "?="].into_iter().enumerate() {
+                let mut file = File::create(&makefile)?;
+                writeln!(&file, "{var:<width$}{op:<width$}whatever", width = i + 1)?;
+                file.flush()?;
+                assert_eq!(200, Pgxs::confidence(tmp.as_ref()), "{name} {var}");
+
+                // Append PG_CONFIG, should get full confidence.
+                let var = "PG_CONFIG";
+                writeln!(&file, "{var:<width$}{op:<width$}whatever", width = i + 1)?;
+                file.flush()?;
+                assert_eq!(
+                    255,
+                    Pgxs::confidence(tmp.as_ref()),
+                    "{name} {var} PG_CONFIG"
+                );
+            }
+        }
+        fs::remove_file(&makefile)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn new() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let pipe = Pgxs::new(dir.to_path_buf(), false);
+    assert_eq!(dir, pipe.dir);
+    assert!(!pipe.sudo);
+
+    let dir2 = dir.join("corpus");
+    let pipe = Pgxs::new(dir2.to_path_buf(), true);
+    assert_eq!(dir2, pipe.dir);
+    assert!(pipe.sudo);
+}
+
+#[test]
+fn configure_et_al() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let pipe = Pgxs::new(dir.to_path_buf(), false);
+    assert!(pipe.configure().is_ok());
+    assert!(pipe.compile().is_ok());
+    assert!(pipe.test().is_ok());
+    assert!(pipe.install().is_ok());
+}

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -1,13 +1,18 @@
 //! Build Pipeline interface definition.
 
 use crate::error::BuildError;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Defines the interface for build pipelines to configure, compile, and test
 /// PGXN distributions.
 pub(crate) trait Pipeline {
-    /// Creates an instance of a Builder.
+    /// Creates an instance of a Pipeline.
     fn new(dir: PathBuf, sudo: bool) -> Self;
+
+    /// Returns a score for the confidence that this pipeline can build the
+    /// contents of `dir`. A score of 0 means no confidence and 255 means the
+    /// highest confidence.
+    fn confidence(dir: &Path) -> u8;
 
     /// Configures a distribution to build on a particular platform and
     /// Postgres version.
@@ -15,6 +20,9 @@ pub(crate) trait Pipeline {
 
     /// Compiles a distribution on a particular platform and Postgres version.
     fn compile(&self) -> Result<(), BuildError>;
+
+    /// Installs a distribution on a particular platform and Postgres version.
+    fn install(&self) -> Result<(), BuildError>;
 
     /// Tests a distribution a particular platform and Postgres version.
     fn test(&self) -> Result<(), BuildError>;


### PR DESCRIPTION
The PGXS pipeline examines the Makefile (via regular expressions), while the pgrx pipeline examines `Cargo.toml` (via the cargo_toml crate). Each produces a score (0-255), and the highest score wins. If all pipeline candidates return 0 it returns an error. Now Build::new handles a pipeline name specified in the release metadata, while Build::detect figures out which to use when none is specified.

Builder::new now takes a `sudo` param, to indicate whether `sudo` and passes it to Build::new and Build::detect.

Other tweaks:

*   Added an `install` method to the Builder, the Pipeline trait, and
    placeholder implementations in the Pgrx and Pgxs implementations.
*   Removed the `download` and `unpack` methods from the Builder,
    Pipeline trait, and implementations, as the api::Api struct handles
    this functionality.