### PR TITLE
Implement command execution and PGXS configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assertables"
+version = "9.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005f97d2f6ec6956e08b103a6a74dd89da602edcbe3a59379992176fe47e32e5"
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1572,7 @@ dependencies = [
 name = "pgxn_build"
 version = "0.1.0"
 dependencies = [
+ "assertables",
  "cargo_toml",
  "chrono",
  "hex",
@@ -1578,6 +1585,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "temp-env",
  "tempfile",
  "thiserror 2.0.3",
  "ureq",
@@ -2151,6 +2159,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna 1.0.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = "1.0.215"
 serde_json = "1.0.133"
 thiserror = "2.0.3"
 ureq = { version = "2.10.1", features = ["json"] }
-url = "2.5.3"
+url = "2.5.4"
 zip = "2.2.0"
 
 [dev-dependencies]
@@ -35,3 +35,5 @@ httpmock = "0.7.0"
 sha2 = "0.10.8"
 tempfile = "3.14.0"
 hex = "0.4.3"
+temp-env = "0.3.6"
+assertables = "9.4.0"

--- a/src/api/dist/mod.rs
+++ b/src/api/dist/mod.rs
@@ -9,9 +9,6 @@ use std::{borrow::Borrow, io};
 
 use crate::error::BuildError;
 
-#[cfg(test)]
-mod tests;
-
 /// Represents a single distribution release in [`Releases`].
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Release {
@@ -127,3 +124,6 @@ fn latest_version(releases: Option<&[Release]>) -> Option<&Version> {
         Some(list) => Some(list[0].version()),
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/api/dist/tests.rs
+++ b/src/api/dist/tests.rs
@@ -159,6 +159,14 @@ fn versions() -> Result<(), BuildError> {
                 testing: None,
             },
         ),
+        (
+            "no release data",
+            Releases {
+                stable: None,
+                unstable: None,
+                testing: None,
+            },
+        ),
     ] {
         let dist = Dist {
             name: name.to_string(),
@@ -194,6 +202,17 @@ fn versions() -> Result<(), BuildError> {
             None => {
                 assert!(dist.latest_unstable_version().is_none())
             }
+        }
+
+        // Check for error when no release data.
+        if dist.releases.unstable.is_none()
+            && dist.releases.stable.is_none()
+            && dist.releases.testing.is_none()
+        {
+            assert_eq!(
+                "missing release data",
+                dist.best_version().unwrap_err().to_string()
+            );
         }
     }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -68,6 +68,14 @@ pub enum BuildError {
     /// Zip archive error.
     #[error("{0}")]
     Archive(#[from] zip::result::ZipError),
+
+    /// Missing file.
+    #[error("missing {0}")]
+    MissingFile(&'static str),
+
+    /// Command execution failure.
+    #[error("executing `{0:?}`: {1}")]
+    Command(std::process::Command, io::ErrorKind),
 }
 
 impl From<ureq::Error> for BuildError {

--- a/src/pgrx/mod.rs
+++ b/src/pgrx/mod.rs
@@ -4,31 +4,33 @@
 
 use crate::error::BuildError;
 use crate::pipeline::Pipeline;
-use std::path::{Path, PathBuf};
-
-#[cfg(test)]
-mod tests;
+use std::path::Path;
 
 /// Builder implementation for [pgrx] Pipelines.
 ///
 /// [pgrx]: https://github.com/pgcentralfoundation/pgrx
 #[derive(Debug, PartialEq)]
-pub(crate) struct Pgrx {
-    dir: PathBuf,
+pub(crate) struct Pgrx<P: AsRef<Path>> {
     sudo: bool,
+    dir: P,
 }
 
-impl Pipeline for Pgrx {
-    fn new(dir: PathBuf, sudo: bool) -> Self {
-        Pgrx { dir, sudo }
+impl<P: AsRef<Path>> Pipeline<P> for Pgrx<P> {
+    fn new(dir: P, sudo: bool) -> Self {
+        Pgrx { sudo, dir }
+    }
+
+    /// Returns the directory passed to [`Self::new`].
+    fn dir(&self) -> &P {
+        &self.dir
     }
 
     /// Determines the confidence that the Pgrx pipeline can build the
     /// contents of `dir`. Returns 255 if it contains a file named
     /// `Cargo.toml` and lists pgrx as a dependency. Otherwise returns 1 if
     /// `Cargo.toml` exists and 0 if it does not.
-    fn confidence(dir: &Path) -> u8 {
-        let file = dir.join("Cargo.toml");
+    fn confidence(dir: P) -> u8 {
+        let file = dir.as_ref().join("Cargo.toml");
         if !file.exists() {
             return 0;
         }
@@ -65,3 +67,6 @@ impl Pipeline for Pgrx {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/pgrx/tests.rs
+++ b/src/pgrx/tests.rs
@@ -27,20 +27,22 @@ fn confidence() -> Result<(), BuildError> {
 #[test]
 fn new() {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let pipe = Pgrx::new(dir.to_path_buf(), false);
+    let pipe = Pgrx::new(dir, false);
     assert_eq!(dir, pipe.dir);
+    assert_eq!(&dir, pipe.dir());
     assert!(!pipe.sudo);
 
     let dir2 = dir.join("corpus");
-    let pipe = Pgrx::new(dir2.to_path_buf(), true);
+    let pipe = Pgrx::new(dir2.as_path(), true);
     assert_eq!(dir2, pipe.dir);
+    assert_eq!(&dir2, pipe.dir());
     assert!(pipe.sudo);
 }
 
 #[test]
 fn configure_et_al() {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let pipe = Pgrx::new(dir.to_path_buf(), false);
+    let pipe = Pgrx::new(dir, false);
     assert!(pipe.configure().is_ok());
     assert!(pipe.compile().is_ok());
     assert!(pipe.test().is_ok());

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -1,18 +1,18 @@
 //! Build Pipeline interface definition.
 
 use crate::error::BuildError;
-use std::path::{Path, PathBuf};
+use std::{path::Path, process::Command};
 
 /// Defines the interface for build pipelines to configure, compile, and test
 /// PGXN distributions.
-pub(crate) trait Pipeline {
+pub(crate) trait Pipeline<P: AsRef<Path>> {
     /// Creates an instance of a Pipeline.
-    fn new(dir: PathBuf, sudo: bool) -> Self;
+    fn new(dir: P, sudo: bool) -> Self;
 
     /// Returns a score for the confidence that this pipeline can build the
     /// contents of `dir`. A score of 0 means no confidence and 255 means the
     /// highest confidence.
-    fn confidence(dir: &Path) -> u8;
+    fn confidence(dir: P) -> u8;
 
     /// Configures a distribution to build on a particular platform and
     /// Postgres version.
@@ -26,4 +26,41 @@ pub(crate) trait Pipeline {
 
     /// Tests a distribution a particular platform and Postgres version.
     fn test(&self) -> Result<(), BuildError>;
+
+    /// Returns the directory passed to [`new`].
+    fn dir(&self) -> &P;
+
+    /// Run a command. Runs it with elevated privileges using `sudo` unless
+    /// it's on Windows.
+    fn run<S, I>(&self, cmd: &str, args: I, sudo: bool) -> Result<(), BuildError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<std::ffi::OsStr>,
+    {
+        // Ignore the `sudo` param on Windows, since it is not currently
+        // possible to mock it on Windows (see notes in tests.rs), and though
+        // it [exists](https://github.com/microsoft/sudo), it's not clear
+        // whether it's the right thing to require, or if elevated privileges
+        // will be required at all in Windows. Revisit once all the
+        // dependencies for building extensions on Windows are recognized and
+        // put to use to formally support building and installing extensions
+        // on Windows.
+        let mut cmd = if cfg!(not(windows)) && sudo {
+            let mut c = Command::new("sudo");
+            c.arg(cmd);
+            c
+        } else {
+            Command::new(cmd)
+        };
+
+        cmd.args(args);
+        cmd.current_dir(self.dir());
+        match cmd.output() {
+            Ok(_) => Ok(()),
+            Err(e) => Err(BuildError::Command(cmd, e.kind())),
+        }
+    }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/pipeline/tests.rs
+++ b/src/pipeline/tests.rs
@@ -1,0 +1,91 @@
+use super::*;
+#[cfg(target_family = "unix")]
+use std::os::unix::fs::PermissionsExt;
+use std::{env, fs::File, io::Write};
+use tempfile::tempdir;
+
+struct TestPipeline<P: AsRef<Path>> {
+    dir: P,
+}
+
+// Create a mock version of the trait.
+#[cfg(test)]
+impl<P: AsRef<Path>> Pipeline<P> for TestPipeline<P> {
+    fn new(dir: P, _: bool) -> Self {
+        TestPipeline { dir }
+    }
+    fn dir(&self) -> &P {
+        &self.dir
+    }
+
+    fn confidence(_: P) -> u8 {
+        0
+    }
+    fn configure(&self) -> Result<(), BuildError> {
+        Ok(())
+    }
+    fn compile(&self) -> Result<(), BuildError> {
+        Ok(())
+    }
+    fn install(&self) -> Result<(), BuildError> {
+        Ok(())
+    }
+    fn test(&self) -> Result<(), BuildError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn run() -> Result<(), BuildError> {
+    let tmp = tempdir()?;
+
+    let pipe = TestPipeline::new(&tmp, false);
+    if let Err(e) = pipe.run("echo", ["hello"], false) {
+        panic!("echo hello failed: {e}");
+    }
+
+    // Mock up sudo command as a simple shell script.
+    #[cfg(target_family = "windows")]
+    {
+        // This should work but does not, even though it's put into the path
+        // below, because Command only supports `.exe` files:
+        //
+        // > Note on Windows: For executable files with the .exe extension, it
+        // > can be omitted when specifying the program for this Command.
+        // > However, if the file has a different extension, a filename
+        // > including the extension needs to be provided, otherwise the file
+        // > won’t be found.
+        //
+        // https://doc.rust-lang.org/std/process/struct.Command.html#platform-specific-behavior
+        //
+        // For now run() ignores the `sudo` param, since it's not clear it's
+        // the right command anyway.
+        let sudo = tmp.path().join("sudo.bat");
+        let file = File::create(&sudo)?;
+        writeln!(&file, "@echo off\r\necho %*\r\n")?;
+    }
+    #[cfg(not(target_family = "windows"))]
+    {
+        let sudo = tmp.path().join("sudo");
+        let file = File::create(&sudo)?;
+        writeln!(&file, "#! /bin/sh\n\necho \"$@\"\n")?;
+        let mut perms = std::fs::metadata(&sudo)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&sudo, perms)?;
+    }
+
+    // Create a PATH variable that searches tmp first.
+    let path = env::var("PATH").unwrap();
+    let path = [tmp.path().to_path_buf()]
+        .into_iter()
+        .chain(env::split_paths(&path));
+
+    // Run sudo echo with the path set.
+    temp_env::with_var("PATH", Some(env::join_paths(path).unwrap()), || {
+        if let Err(e) = pipe.run("echo", ["hello"], true) {
+            panic!("echo hello failed: {e}");
+        }
+    });
+
+    Ok(())
+}


### PR DESCRIPTION
Add `run` to the `Pipeline` trait with a full implementation that executes a command. It takes a `sudo` param to use execute the command with elevated privileges, though it's currently ignored on Windows (as copiously covered in comments).

Implement the basic behavior for configuring, compiling, testing, and installing PGXS extensions, and fully test the `configure` implementation. Note that the tests actually execute a `configure` shell script. This works on the GitHub Windows runner, too, which have Bash installed.

In the process, return to storing the directory in the pipeline implementations and setting them on the Command object, because then the scope of the directory-setting is in the command, and not the parent process. Otherwise we'd have to get up to a bunch of shenanigans to change to the working directory in a thread-safe way. Fortunately, I finally worked out the pattern to store the directory as an `AsRef<Path>` everywhere, which simplifies usability quite a bit (at the expense of a bunch of annotations).

Other changes:

*   Upgrade the `url` crate, since 2.5.3 has been yanked (resolves #13).
*   Adopt the `assertables` crate for nicer test assertions. Will be used more in the future.
*   Move `#[cfg(test)]` to the bottom of module files, because `--excl-start` in `.ci/test-cover` excludes everything after that declaration, not just the module. As a result, add a test for no release data to `api/dist`.