### PR TITLE
Use rust to mock CLI apps in tests

### DIFF
--- a/mocks/echo.rs
+++ b/mocks/echo.rs
@@ -1,0 +1,5 @@
+// Simple echo-like app.
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    println!("{}", &args.join(" "));
+}

--- a/mocks/exit_err.rs
+++ b/mocks/exit_err.rs
@@ -1,6 +1,6 @@
 // Simple app that returns an error.
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    println!("DED: {}", &args[1..].join(" "));
+    eprintln!("DED: {}", &args[1..].join(" "));
     std::process::exit(2)
 }

--- a/src/pg_config/mod.rs
+++ b/src/pg_config/mod.rs
@@ -21,7 +21,7 @@ impl PgConfig {
         if !out.status.success() {
             return Err(BuildError::Command(
                 format!("{:?}", cmd),
-                String::from_utf8_lossy(&out.stdout).to_string(),
+                String::from_utf8_lossy(&out.stderr).to_string(),
             ));
         }
 

--- a/src/pg_config/tests.rs
+++ b/src/pg_config/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::tests::compile_mock;
 use assertables::*;
 use tempfile::tempdir;
 
@@ -110,16 +111,4 @@ fn pg_config_err() {
             assert_ends_with!(e.to_string(), "nonesuch\"`: entity not found");
         }
     }
-}
-
-fn compile_mock(name: &str, dest: &str) {
-    let src = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("mocks")
-        .join(format!("{name}.rs"))
-        .display()
-        .to_string();
-    Command::new("rustc")
-        .args([&src, "-o", dest])
-        .output()
-        .unwrap();
 }

--- a/src/pgxs/tests.rs
+++ b/src/pgxs/tests.rs
@@ -79,14 +79,11 @@ fn configure() -> Result<(), BuildError> {
 
     // Now try with a configure file.
     let path = tmp.path().join("configure");
-    #[cfg(target_family = "windows")]
     {
         let cfg = File::create(&path)?;
+        #[cfg(target_family = "windows")]
         writeln!(&cfg, "@echo off\r\necho configuring something...\r\n")?;
-    }
-    #[cfg(not(target_family = "windows"))]
-    {
-        let cfg = File::create(&path)?;
+        #[cfg(not(target_family = "windows"))]
         writeln!(&cfg, "#! /bin/sh\n\necho configuring something...\n")?;
     }
     match pipe.configure() {
@@ -106,10 +103,8 @@ fn configure() -> Result<(), BuildError> {
 
     // Make it executable.
     #[cfg(target_family = "windows")]
-    {
-        // Turn it into a batch file.
-        std::fs::rename(path, tmp.path().join("configure.bat"))?;
-    }
+    // Turn it into a batch file.
+    std::fs::rename(path, tmp.path().join("configure.bat"))?;
     #[cfg(not(target_family = "windows"))]
     {
         // Make it executable.
@@ -128,7 +123,7 @@ fn configure() -> Result<(), BuildError> {
 fn compile() -> Result<(), BuildError> {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let pipe = Pgxs::new(dir, false);
-    assert!(pipe.compile().is_ok());
+    assert!(pipe.compile().is_err());
     Ok(())
 }
 
@@ -136,7 +131,7 @@ fn compile() -> Result<(), BuildError> {
 fn test() -> Result<(), BuildError> {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let pipe = Pgxs::new(dir, false);
-    assert!(pipe.test().is_ok());
+    assert!(pipe.test().is_err());
     Ok(())
 }
 
@@ -144,6 +139,6 @@ fn test() -> Result<(), BuildError> {
 fn install() -> Result<(), BuildError> {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let pipe = Pgxs::new(dir, false);
-    assert!(pipe.install().is_ok());
+    assert!(pipe.install().is_err());
     Ok(())
 }


### PR DESCRIPTION
Already done in the pg_config tests, but adapted for all the other tests that actually call CLIs. Move `compile_mock` to `lib/tests.rs` to use throughout tests, and then use the new `mocks/echo.rs` to mock `sudo` and `configure`, and remove all the code building conditional shell or batch scripts. Also remove the comments about `sudo` on Windows, since the tests now successfully mock it.

Add code to check Command success, too. This was previously lacking, leading to execution that succeeded because an app exists (e.g. `make`) and therefore successfully executed but exited with an error. For that case, check `status.success` on command output and pass `stderr` to the resulting error if not successful. Fix a bug thus found where `mocks/exit_err.rs` was printing to STDOUT instead of STDERR. Also fix PGXS tests that were previously successfully executing but should not have been.