### PR TITLE
Integrate PgConfig into pipeline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod pgxs;
 mod pipeline;
 
 use crate::{error::BuildError, pgrx::Pgrx, pgxs::Pgxs, pipeline::Pipeline};
+use pg_config::PgConfig;
 use pgxn_meta::{dist, release::Release};
 use std::path::Path;
 
@@ -31,17 +32,22 @@ enum Build<P: AsRef<Path>> {
 impl<P: AsRef<Path>> Build<P> {
     /// Returns a build pipeline identified by `pipe`, or an error if `pipe`
     /// is unknown.
-    fn new(pipe: &dist::Pipeline, dir: P, sudo: bool) -> Result<Build<P>, BuildError> {
+    fn new(
+        pipe: &dist::Pipeline,
+        dir: P,
+        cfg: PgConfig,
+        sudo: bool,
+    ) -> Result<Build<P>, BuildError> {
         match pipe {
-            dist::Pipeline::Pgxs => Ok(Build::Pgxs(Pgxs::new(dir, sudo))),
-            dist::Pipeline::Pgrx => Ok(Build::Pgrx(Pgrx::new(dir, sudo))),
+            dist::Pipeline::Pgxs => Ok(Build::Pgxs(Pgxs::new(dir, cfg, sudo))),
+            dist::Pipeline::Pgrx => Ok(Build::Pgrx(Pgrx::new(dir, cfg, sudo))),
             _ => Err(BuildError::UnknownPipeline(pipe.to_string())),
         }
     }
 
     /// Attempts to detect and return the appropriate build pipeline to build
     /// the contents of `dir`. Returns an error if no pipeline can do so.
-    fn detect(dir: P, sudo: bool) -> Result<Build<P>, BuildError> {
+    fn detect(dir: P, cfg: PgConfig, sudo: bool) -> Result<Build<P>, BuildError> {
         // Start with PGXS.
         let mut score = Pgxs::confidence(&dir);
         let mut pipe = dist::Pipeline::Pgxs;
@@ -61,8 +67,8 @@ impl<P: AsRef<Path>> Build<P> {
 
         // Construct the winner.
         match pipe {
-            dist::Pipeline::Pgrx => Ok(Build::Pgrx(Pgrx::new(dir, sudo))),
-            dist::Pipeline::Pgxs => Ok(Build::Pgxs(Pgxs::new(dir, sudo))),
+            dist::Pipeline::Pgrx => Ok(Build::Pgrx(Pgrx::new(dir, cfg, sudo))),
+            dist::Pipeline::Pgxs => Ok(Build::Pgxs(Pgxs::new(dir, cfg, sudo))),
             _ => unreachable!("unknown pipelines {pipe}"),
         }
     }
@@ -77,15 +83,15 @@ pub struct Builder<P: AsRef<Path>> {
 
 impl<P: AsRef<Path>> Builder<P> {
     /// Creates and returns a new builder using the appropriate pipeline.
-    pub fn new(dir: P, meta: Release, sudo: bool) -> Result<Self, BuildError> {
+    pub fn new(dir: P, meta: Release, cfg: PgConfig, sudo: bool) -> Result<Self, BuildError> {
         let pipeline = if let Some(deps) = meta.dependencies() {
             if let Some(pipe) = deps.pipeline() {
-                Build::new(pipe, dir, sudo)?
+                Build::new(pipe, dir, cfg, sudo)?
             } else {
-                Build::detect(dir, sudo)?
+                Build::detect(dir, cfg, sudo)?
             }
         } else {
-            Build::detect(dir, sudo)?
+            Build::detect(dir, cfg, sudo)?
         };
 
         Ok(Builder { pipeline, meta })

--- a/src/pg_config/mod.rs
+++ b/src/pg_config/mod.rs
@@ -7,7 +7,8 @@ use std::{
 
 use crate::error::BuildError;
 
-pub(crate) struct PgConfig(HashMap<String, String>);
+#[derive(Debug, PartialEq, Clone)]
+pub struct PgConfig(HashMap<String, String>);
 
 impl PgConfig {
     /// Executes `pg_config`, parses the output, and returns a `PgConfig`
@@ -38,6 +39,11 @@ impl PgConfig {
         }
 
         Ok(PgConfig(cfg))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_map(map: HashMap<String, String>) -> Self {
+        Self(map)
     }
 
     /// Returns the `pg_config` value for `cfg`, which should be a lowercase

--- a/src/pgrx/mod.rs
+++ b/src/pgrx/mod.rs
@@ -3,6 +3,7 @@
 //! [pgrx]: https://github.com/pgcentralfoundation/pgrx
 
 use crate::error::BuildError;
+use crate::pg_config::PgConfig;
 use crate::pipeline::Pipeline;
 use std::path::Path;
 
@@ -12,17 +13,23 @@ use std::path::Path;
 #[derive(Debug, PartialEq)]
 pub(crate) struct Pgrx<P: AsRef<Path>> {
     sudo: bool,
+    cfg: PgConfig,
     dir: P,
 }
 
 impl<P: AsRef<Path>> Pipeline<P> for Pgrx<P> {
-    fn new(dir: P, sudo: bool) -> Self {
-        Pgrx { sudo, dir }
+    fn new(dir: P, cfg: PgConfig, sudo: bool) -> Self {
+        Pgrx { sudo, cfg, dir }
     }
 
     /// Returns the directory passed to [`Self::new`].
     fn dir(&self) -> &P {
         &self.dir
+    }
+
+    /// Returns the PgConfig passed to [`Self::new`].
+    fn pg_config(&self) -> &PgConfig {
+        &self.cfg
     }
 
     /// Determines the confidence that the Pgrx pipeline can build the

--- a/src/pgrx/tests.rs
+++ b/src/pgrx/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::{fs::File, io::Write};
+use std::{collections::HashMap, fs::File, io::Write};
 use tempfile::tempdir;
 
 #[test]
@@ -27,22 +27,26 @@ fn confidence() -> Result<(), BuildError> {
 #[test]
 fn new() {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let pipe = Pgrx::new(dir, false);
+    let cfg = PgConfig::from_map(HashMap::new());
+    let pipe = Pgrx::new(dir, cfg.clone(), false);
     assert_eq!(dir, pipe.dir);
     assert_eq!(&dir, pipe.dir());
+    assert_eq!(&cfg, pipe.pg_config());
     assert!(!pipe.sudo);
 
     let dir2 = dir.join("corpus");
-    let pipe = Pgrx::new(dir2.as_path(), true);
+    let cfg2 = PgConfig::from_map(HashMap::from([("bindir".to_string(), "bin".to_string())]));
+    let pipe = Pgrx::new(dir2.as_path(), cfg2.clone(), true);
     assert_eq!(dir2, pipe.dir);
     assert_eq!(&dir2, pipe.dir());
+    assert_eq!(&cfg2, pipe.pg_config());
     assert!(pipe.sudo);
 }
 
 #[test]
 fn configure_et_al() {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let pipe = Pgrx::new(dir, false);
+    let pipe = Pgrx::new(dir, PgConfig::from_map(HashMap::new()), false);
     assert!(pipe.configure().is_ok());
     assert!(pipe.compile().is_ok());
     assert!(pipe.test().is_ok());

--- a/src/pgxs/mod.rs
+++ b/src/pgxs/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! [PGXS]: https://www.postgresql.org/docs/current/extend-pgxs.html
 
-use crate::error::BuildError;
 use crate::pipeline::Pipeline;
+use crate::{error::BuildError, pg_config::PgConfig};
 use log::info;
 use regex::Regex;
 use std::{
@@ -18,12 +18,13 @@ use std::{
 #[derive(Debug, PartialEq)]
 pub(crate) struct Pgxs<P: AsRef<Path>> {
     sudo: bool,
+    cfg: PgConfig,
     dir: P,
 }
 
 impl<P: AsRef<Path>> Pipeline<P> for Pgxs<P> {
-    fn new(dir: P, sudo: bool) -> Self {
-        Pgxs { sudo, dir }
+    fn new(dir: P, cfg: PgConfig, sudo: bool) -> Self {
+        Pgxs { sudo, cfg, dir }
     }
 
     /// Determines the confidence that the Pgxs pipeline can build the
@@ -68,6 +69,11 @@ impl<P: AsRef<Path>> Pipeline<P> for Pgxs<P> {
     /// Returns the directory passed to [`Self::new`].
     fn dir(&self) -> &P {
         &self.dir
+    }
+
+    /// Returns the PgConfig passed to [`Self::new`].
+    fn pg_config(&self) -> &PgConfig {
+        &self.cfg
     }
 
     fn configure(&self) -> Result<(), BuildError> {

--- a/src/pgxs/tests.rs
+++ b/src/pgxs/tests.rs
@@ -3,6 +3,7 @@ use assertables::*;
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::PermissionsExt;
 use std::{
+    collections::HashMap,
     fs::{self, File},
     io::Write,
 };
@@ -55,22 +56,26 @@ fn confidence() -> Result<(), BuildError> {
 #[test]
 fn new() {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let pipe = Pgxs::new(dir, false);
+    let cfg = PgConfig::from_map(HashMap::new());
+    let pipe = Pgxs::new(dir, cfg.clone(), false);
     assert_eq!(dir, pipe.dir);
     assert_eq!(&dir, pipe.dir());
+    assert_eq!(&cfg, pipe.pg_config());
     assert!(!pipe.sudo);
 
     let dir2 = dir.join("corpus");
-    let pipe = Pgxs::new(dir2.as_path(), true);
+    let cfg2 = PgConfig::from_map(HashMap::from([("bindir".to_string(), "bin".to_string())]));
+    let pipe = Pgxs::new(dir2.as_path(), cfg2.clone(), true);
     assert_eq!(dir2, pipe.dir);
     assert_eq!(&dir2, pipe.dir());
+    assert_eq!(&cfg2, pipe.pg_config());
     assert!(pipe.sudo);
 }
 
 #[test]
 fn configure() -> Result<(), BuildError> {
     let tmp = tempdir()?;
-    let pipe = Pgxs::new(&tmp, false);
+    let pipe = Pgxs::new(&tmp, PgConfig::from_map(HashMap::new()), false);
 
     // Try with no Configure file.
     if let Err(e) = pipe.configure() {
@@ -122,7 +127,7 @@ fn configure() -> Result<(), BuildError> {
 #[test]
 fn compile() -> Result<(), BuildError> {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let pipe = Pgxs::new(dir, false);
+    let pipe = Pgxs::new(dir, PgConfig::from_map(HashMap::new()), false);
     assert!(pipe.compile().is_err());
     Ok(())
 }
@@ -130,7 +135,7 @@ fn compile() -> Result<(), BuildError> {
 #[test]
 fn test() -> Result<(), BuildError> {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let pipe = Pgxs::new(dir, false);
+    let pipe = Pgxs::new(dir, PgConfig::from_map(HashMap::new()), false);
     assert!(pipe.test().is_err());
     Ok(())
 }
@@ -138,7 +143,7 @@ fn test() -> Result<(), BuildError> {
 #[test]
 fn install() -> Result<(), BuildError> {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let pipe = Pgxs::new(dir, false);
+    let pipe = Pgxs::new(dir, PgConfig::from_map(HashMap::new()), false);
     assert!(pipe.install().is_err());
     Ok(())
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -1,6 +1,6 @@
 //! Build Pipeline interface definition.
 
-use crate::error::BuildError;
+use crate::{error::BuildError, pg_config::PgConfig};
 use log::debug;
 use std::{io::Write, path::Path, process::Command};
 
@@ -8,7 +8,7 @@ use std::{io::Write, path::Path, process::Command};
 /// PGXN distributions.
 pub(crate) trait Pipeline<P: AsRef<Path>> {
     /// Creates an instance of a Pipeline.
-    fn new(dir: P, sudo: bool) -> Self;
+    fn new(dir: P, pg_config: PgConfig, sudo: bool) -> Self;
 
     /// Returns a score for the confidence that this pipeline can build the
     /// contents of `dir`. A score of 0 means no confidence and 255 means the
@@ -30,6 +30,9 @@ pub(crate) trait Pipeline<P: AsRef<Path>> {
 
     /// Returns the directory passed to [`new`].
     fn dir(&self) -> &P;
+
+    /// Returns the PgConfig passed to [`new`].
+    fn pg_config(&self) -> &PgConfig;
 
     /// Attempts to write a temporary file to `dir` and returns `true` on
     /// success and `false` on failure. The temporary file will be deleted.


### PR DESCRIPTION
Pass a PgConfig to the appropriate constructors, and add an accessor method for it to Pipeline. Add a test-only `from_map` constructor to PgConfig to simplify testing, and make PgConfig public so that it can be passed to `Builder::new`.